### PR TITLE
Fix column name in streets table

### DIFF
--- a/config_template.py
+++ b/config_template.py
@@ -49,7 +49,7 @@ streetGeomCol = 'geom_way'  # geometry column (LineString) for street edge
 startNodeCol = 'source'     # id of node at which the street edge starts
 endNodeCol = 'target'       # id of node at which the street edge ends
 travelCostCol = 'cost'      # generalized cost to go from startNode to endNode
-travelCostReverseCol = 'reverse_cost'  # generalized cost to go from endNode to startNode. Can be same as travelCostCol if you have no one-way streets
+travelCostReverseCol = 'reverse_co'  # generalized cost to go from endNode to startNode. Can be same as travelCostCol if you have no one-way streets
 streetLengthCol = 'km'      # length of street, in km
 speedLimitCol = 'kmh'       # speed limit on street, in km per hour
 


### PR DESCRIPTION
The column names in the sample data provided in `testdata/sf_streets.zip` do not match the config file - specifically 'reverse_cost' is instead 'reverse_co' in the file (I assume because of column name length limits for the shapefile format). This is a very small change to make the sample data work.